### PR TITLE
refactor declarative key

### DIFF
--- a/assets/key.css
+++ b/assets/key.css
@@ -103,23 +103,6 @@
   border-radius: 3px;
 }
 
-.bakerloo { background-color: #B36305; }
-.central { background-color: #E32017; }
-.circle { background-color: #FFD300; }
-.district { background-color: #00782A; }
-.hammersmith { background-color: #F3A9BB; }
-.jubilee { background-color: #A0A5A9; }
-.metropolitan { background-color: #9B0056; }
-.northern { background-color: #000000; }
-.piccadilly { background-color: #003688; }
-.victoria { background-color: #0098D4; }
-.waterloo { background-color: #95CDBA; }
-.overground { background-color: #EE7C0E; }
-.dlr { background-color: #00A4A7; }
-.elizabeth { background-color: #6950A1; }
-.tram { background-color: #84B817; }
-.cablecar { background-color: #E21836; }
-
 .map-symbol {
   display: inline-block;
   width: 20px;

--- a/assets/tfl.css
+++ b/assets/tfl.css
@@ -17,22 +17,6 @@
   /* TfL colors */
   --tfl-blue: #0019A8;
   --tfl-red: #DC241F;
-  --bakerloo: #B36305;
-  --central: #E32017;
-  --circle: #FFD300;
-  --district: #00782A;
-  --hammersmith: #F3A9BB;
-  --jubilee: #A0A5A9;
-  --metropolitan: #9B0056;
-  --northern: #000000;
-  --piccadilly: #003688;
-  --victoria: #0098D4;
-  --waterloo: #95CDBA;
-  --overground: #EE7C0E;
-  --dlr: #00A4A7;
-  --elizabeth: #9364CD;
-  --tram: #84B817;
-  --cablecar: #E21836;
 }
 
 /* Global styles */
@@ -274,23 +258,6 @@ nav ul li a:hover {
   width: 30px;
   display: inline-block;
 }
-
-.color-line.bakerloo { background-color: var(--bakerloo); }
-.color-line.central { background-color: var(--central); }
-.color-line.circle { background-color: var(--circle); }
-.color-line.district { background-color: var(--district); }
-.color-line.hammersmith { background-color: var(--hammersmith); }
-.color-line.jubilee { background-color: var(--jubilee); }
-.color-line.metropolitan { background-color: var(--metropolitan); }
-.color-line.northern { background-color: var(--northern); }
-.color-line.piccadilly { background-color: var(--piccadilly); }
-.color-line.victoria { background-color: var(--victoria); }
-.color-line.waterloo { background-color: var(--waterloo); }
-.color-line.overground { background-color: var(--overground); }
-.color-line.dlr { background-color: var(--dlr); }
-.color-line.elizabeth { background-color: var(--elizabeth); }
-.color-line.tram { background-color: var(--tram); }
-.color-line.cablecar { background-color: var(--cablecar); }
 
 /* Map symbols for the key */
 .map-symbol {

--- a/src/app/js/key_control.js
+++ b/src/app/js/key_control.js
@@ -4,7 +4,6 @@ class KeyControl {
     this._map = null;
     this._container = null;
     this._button = null;
-    this._keyPanel = null;
   }
 
   onAdd(map) {
@@ -21,48 +20,16 @@ class KeyControl {
     this._button.title = 'Show map key';
     this._button.setAttribute('aria-label', 'Show map key');
 
-    // Create the key panel (initially hidden)
-    this._keyPanel = document.createElement('div');
-    this._keyPanel.className = 'oim-key-panel';
-
-    // Add header
-    const header = document.createElement('div');
-    header.className = 'oim-key-header';
-
-    const title = document.createElement('h2');
-    title.textContent = 'Key';
-
-    const closeButton = document.createElement('button');
-    closeButton.className = 'oim-key-close';
-    closeButton.textContent = '×';
-
-    header.appendChild(title);
-    header.appendChild(closeButton);
-
-    // Add body
-    const body = document.createElement('div');
-    body.className = 'oim-key-body';
-
-    // Populate key content
-    this._populateKeyContent(body);
-
-    // Add components to the panel
-    this._keyPanel.appendChild(header);
-    this._keyPanel.appendChild(body);
-
-    // Add panel to document body
-    document.body.appendChild(this._keyPanel);
-
     // Add button to container
     this._container.appendChild(this._button);
 
-    // Add event listeners
+    // Add event listeners - call the Rust-defined function if available
     this._button.addEventListener('click', () => {
-      this._keyPanel.classList.add('visible');
-    });
-
-    closeButton.addEventListener('click', () => {
-      this._keyPanel.classList.remove('visible');
+      if (window.openTflKeyPanel) {
+        window.openTflKeyPanel();
+      } else {
+        console.log("Key button click failed: no openTflKeyPanel exposed to JS on the window");
+      }
     });
 
     return this._container;
@@ -72,78 +39,11 @@ class KeyControl {
     if (this._container && this._container.parentNode) {
       this._container.parentNode.removeChild(this._container);
     }
-
-    if (this._keyPanel && this._keyPanel.parentNode) {
-      this._keyPanel.parentNode.removeChild(this._keyPanel);
-    }
-
     this._map = null;
   }
 
   getDefaultPosition() {
     return 'top-right';
-  }
-
-  _populateKeyContent(container) {
-    // Add Underground Lines section
-    container.appendChild(this._createSection('Underground Lines', [
-      { name: 'Bakerloo', className: 'color-line bakerloo' },
-      { name: 'Central', className: 'color-line central' },
-      { name: 'Circle', className: 'color-line circle' },
-      { name: 'District', className: 'color-line district' },
-      { name: 'Hammersmith & City', className: 'color-line hammersmith-city' },
-      { name: 'Jubilee', className: 'color-line jubilee' },
-      { name: 'Metropolitan', className: 'color-line metropolitan' },
-      { name: 'Northern', className: 'color-line northern' },
-      { name: 'Piccadilly', className: 'color-line piccadilly' },
-      { name: 'Victoria', className: 'color-line victoria' },
-      { name: 'Waterloo & City', className: 'color-line waterloo-city' }
-    ]));
-
-    // Add Other Rail section
-    container.appendChild(this._createSection('Other Rail', [
-      { name: 'Overground', className: 'color-line overground' },
-      { name: 'DLR', className: 'color-line dlr' },
-      { name: 'Elizabeth Line', className: 'color-line elizabeth' },
-      { name: 'Trams', className: 'color-line tram' },
-      { name: 'Cable Car', className: 'color-line cable-car' }
-    ]));
-
-    // Add Other Features section
-    container.appendChild(this._createSection('Other Features', [
-      { name: 'Station', className: 'map-symbol station' },
-      { name: 'Interchange', className: 'map-symbol interchange' },
-      { name: 'Depot', className: 'map-symbol depot' }
-    ]));
-  }
-
-  _createSection(title, items) {
-    const section = document.createElement('div');
-
-    const heading = document.createElement('h3');
-    heading.textContent = title;
-    section.appendChild(heading);
-
-    const table = document.createElement('table');
-
-    items.forEach(item => {
-      const row = document.createElement('tr');
-
-      const labelCell = document.createElement('td');
-      labelCell.textContent = item.name;
-
-      const symbolCell = document.createElement('td');
-      const symbolDiv = document.createElement('div');
-      symbolDiv.className = item.className;
-      symbolCell.appendChild(symbolDiv);
-
-      row.appendChild(labelCell);
-      row.appendChild(symbolCell);
-      table.appendChild(row);
-    });
-
-    section.appendChild(table);
-    return section;
   }
 }
 

--- a/src/app/js/key_control.js
+++ b/src/app/js/key_control.js
@@ -91,13 +91,13 @@ class KeyControl {
       { name: 'Central', className: 'color-line central' },
       { name: 'Circle', className: 'color-line circle' },
       { name: 'District', className: 'color-line district' },
-      { name: 'Hammersmith & City', className: 'color-line hammersmith' },
+      { name: 'Hammersmith & City', className: 'color-line hammersmith-city' },
       { name: 'Jubilee', className: 'color-line jubilee' },
       { name: 'Metropolitan', className: 'color-line metropolitan' },
       { name: 'Northern', className: 'color-line northern' },
       { name: 'Piccadilly', className: 'color-line piccadilly' },
       { name: 'Victoria', className: 'color-line victoria' },
-      { name: 'Waterloo & City', className: 'color-line waterloo' }
+      { name: 'Waterloo & City', className: 'color-line waterloo-city' }
     ]));
 
     // Add Other Rail section
@@ -106,7 +106,7 @@ class KeyControl {
       { name: 'DLR', className: 'color-line dlr' },
       { name: 'Elizabeth Line', className: 'color-line elizabeth' },
       { name: 'Trams', className: 'color-line tram' },
-      { name: 'Cable Car', className: 'color-line cablecar' }
+      { name: 'Cable Car', className: 'color-line cable-car' }
     ]));
 
     // Add Other Features section

--- a/src/app/key_panel.rs
+++ b/src/app/key_panel.rs
@@ -1,5 +1,5 @@
+use crate::data::line_definitions::{get_other_rail_lines, get_underground_lines};
 use dioxus::prelude::*;
-use crate::data::line_definitions::{get_underground_lines, get_other_rail_lines};
 
 #[component]
 pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {

--- a/src/app/key_panel.rs
+++ b/src/app/key_panel.rs
@@ -31,7 +31,7 @@ pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {
                             td { "{line.name}" }
                             td {
                                 div {
-                                    class: format_args!("color-line {}", line.id.replace("-", "_"))
+                                    class: format_args!("color-line {}", line.id)
                                 }
                             }
                         }
@@ -46,7 +46,7 @@ pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {
                             td { "{line.name}" }
                             td {
                                 div {
-                                    class: format_args!("color-line {}", line.id.replace("-", "_"))
+                                    class: format_args!("color-line {}", line.id)
                                 }
                             }
                         }

--- a/src/app/key_panel.rs
+++ b/src/app/key_panel.rs
@@ -1,7 +1,11 @@
 use dioxus::prelude::*;
+use crate::data::line_definitions::{get_underground_lines, get_other_rail_lines};
 
 #[component]
 pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {
+    let underground_lines = get_underground_lines();
+    let other_rail_lines = get_other_rail_lines();
+
     rsx! {
         div {
             class: if visible { "oim-key-panel visible" } else { "oim-key-panel" },
@@ -21,91 +25,14 @@ pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {
 
                 h3 { "Underground Lines" }
                 table {
-                    tr {
-                        td { "Bakerloo" }
-                        td {
-                            div {
-                                class: "color-line bakerloo"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Central" }
-                        td {
-                            div {
-                                class: "color-line central"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Circle" }
-                        td {
-                            div {
-                                class: "color-line circle"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "District" }
-                        td {
-                            div {
-                                class: "color-line district"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Hammersmith & City" }
-                        td {
-                            div {
-                                class: "color-line hammersmith"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Jubilee" }
-                        td {
-                            div {
-                                class: "color-line jubilee"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Metropolitan" }
-                        td {
-                            div {
-                                class: "color-line metropolitan"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Northern" }
-                        td {
-                            div {
-                                class: "color-line northern"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Piccadilly" }
-                        td {
-                            div {
-                                class: "color-line piccadilly"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Victoria" }
-                        td {
-                            div {
-                                class: "color-line victoria"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Waterloo & City" }
-                        td {
-                            div {
-                                class: "color-line waterloo"
+                    // Dynamically generate rows for underground lines
+                    for line in &underground_lines {
+                        tr {
+                            td { "{line.name}" }
+                            td {
+                                div {
+                                    class: format_args!("color-line {}", line.id.replace("-", "_"))
+                                }
                             }
                         }
                     }
@@ -113,43 +40,14 @@ pub fn KeyPanel(visible: bool, on_close: EventHandler<()>) -> Element {
 
                 h3 { "Other Rail" }
                 table {
-                    tr {
-                        td { "Overground" }
-                        td {
-                            div {
-                                class: "color-line overground"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "DLR" }
-                        td {
-                            div {
-                                class: "color-line dlr"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Elizabeth Line" }
-                        td {
-                            div {
-                                class: "color-line elizabeth"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Trams" }
-                        td {
-                            div {
-                                class: "color-line tram"
-                            }
-                        }
-                    }
-                    tr {
-                        td { "Cable Car" }
-                        td {
-                            div {
-                                class: "color-line cablecar"
+                    // Dynamically generate rows for other rail lines
+                    for line in &other_rail_lines {
+                        tr {
+                            td { "{line.name}" }
+                            td {
+                                div {
+                                    class: format_args!("color-line {}", line.id.replace("-", "_"))
+                                }
                             }
                         }
                     }

--- a/src/app/line_css.rs
+++ b/src/app/line_css.rs
@@ -7,7 +7,7 @@ use dioxus::prelude::*;
 pub fn LineCss() -> Element {
     // Generate CSS content from line definitions
     let css_content = line_definitions::generate_line_css();
-    
+
     rsx! {
         // Use Dioxus's document::Style component to inject CSS
         document::Style { {css_content} }

--- a/src/app/line_css.rs
+++ b/src/app/line_css.rs
@@ -1,0 +1,15 @@
+// src/app/line_css.rs
+use crate::data::line_definitions;
+use dioxus::prelude::*;
+
+/// Component that renders the dynamic CSS for line colors
+#[component]
+pub fn LineCss() -> Element {
+    // Generate CSS content from line definitions
+    let css_content = line_definitions::generate_line_css();
+    
+    rsx! {
+        // Use Dioxus's document::Style component to inject CSS
+        document::Style { {css_content} }
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,9 +6,12 @@ use dioxus::prelude::*;
 
 mod canvas;
 mod key_panel;
+mod line_css;
 mod layer_panel;
 mod simulation; // New module for vehicle simulation
 
+use crate::data::line_definitions::get_line_color;
+use crate::app::line_css::LineCss;
 use crate::data::TflDataRepository;
 use crate::maplibre::helpers;
 use crate::utils::log::{self, LogCategory, with_context};
@@ -297,6 +300,8 @@ pub fn app() -> Element {
     });
 
     rsx! {
+        LineCss {}
+
         document::Link { rel: "icon", href: FAVICON }
         document::Link { rel: "stylesheet", href: MAIN_CSS }
         document::Link { rel: "stylesheet", href: TFL_CSS }
@@ -464,33 +469,34 @@ fn add_tfl_data_to_map(map: &crate::maplibre::bindings::Map, tfl_data: TflDataRe
     });
 }
 
-/// Helper function to get the color for a specific TfL line
-fn get_line_color(line_id: &str) -> String {
-    match line_id {
-        "bakerloo" => "#B36305",
-        "central" => "#E32017",
-        "circle" => "#FFD300",
-        "district" => "#00782A",
-        "hammersmith-city" => "#F3A9BB",
-        "jubilee" => "#A0A5A9",
-        "metropolitan" => "#9B0056",
-        "northern" => "#000000",
-        "piccadilly" => "#003688",
-        "victoria" => "#0098D4",
-        "waterloo-city" => "#95CDBA",
-        "dlr" => "#00A4A7",
-        "london-overground" => "#EE7C0E",
-        "elizabeth" => "#6950A1",
-        "tram" => "#84B817",
-        "cable-car" => "#E21836",
-        "thameslink" => "#C1007C",
-        "liberty" => "#4C6366",
-        "lioness" => "#FFA32B",
-        "mildmay" => "#088ECC",
-        "suffragette" => "#59C274",
-        "weaver" => "#B43983",
-        "windrush" => "#FF2E24",
-        _ => "#777777", // Default gray for unknown lines
-    }
-    .to_string()
-}
+// DEPRECATED FOR crate::data::line_definitions::get_line_color(line_id)
+// /// Helper function to get the color for a specific TfL line
+// fn get_line_color(line_id: &str) -> String {
+//     match line_id {
+//         "bakerloo" => "#B36305",
+//         "central" => "#E32017",
+//         "circle" => "#FFD300",
+//         "district" => "#00782A",
+//         "hammersmith-city" => "#F3A9BB",
+//         "jubilee" => "#A0A5A9",
+//         "metropolitan" => "#9B0056",
+//         "northern" => "#000000",
+//         "piccadilly" => "#003688",
+//         "victoria" => "#0098D4",
+//         "waterloo-city" => "#95CDBA",
+//         "dlr" => "#00A4A7",
+//         "london-overground" => "#EE7C0E",
+//         "elizabeth" => "#6950A1",
+//         "tram" => "#84B817",
+//         "cable-car" => "#E21836",
+//         "thameslink" => "#C1007C",
+//         "liberty" => "#4C6366",
+//         "lioness" => "#FFA32B",
+//         "mildmay" => "#088ECC",
+//         "suffragette" => "#59C274",
+//         "weaver" => "#B43983",
+//         "windrush" => "#FF2E24",
+//         _ => "#777777", // Default gray for unknown lines
+//     }
+//     .to_string()
+// }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -6,13 +6,13 @@ use dioxus::prelude::*;
 
 mod canvas;
 mod key_panel;
-mod line_css;
 mod layer_panel;
+mod line_css;
 mod simulation; // New module for vehicle simulation
 
-use crate::data::line_definitions::get_line_color;
 use crate::app::line_css::LineCss;
 use crate::data::TflDataRepository;
+use crate::data::line_definitions::get_line_color;
 use crate::maplibre::helpers;
 use crate::utils::log::{self, LogCategory, with_context};
 use canvas::Canvas;
@@ -303,31 +303,34 @@ pub fn app() -> Element {
     use_effect(move || {
         with_context("app::key_panel_connection", LogCategory::App, |logger| {
             logger.info("Setting up key panel connection to JavaScript");
-    
+
             // Create a clone of the signal for the closure
             let mut show_key = show_key_panel.clone();
-    
+
             // Create a closure that will open the key panel when called from JavaScript
             // Don't capture logger in this closure!
             let open_key_callback = Closure::wrap(Box::new(move || {
                 // Use direct log calls instead of the captured logger
-                log::debug_with_category(LogCategory::App, "openTflKeyPanel called from JavaScript");
+                log::debug_with_category(
+                    LogCategory::App,
+                    "openTflKeyPanel called from JavaScript",
+                );
                 show_key.set(true);
             }) as Box<dyn FnMut()>);
-    
+
             // Expose the closure to JavaScript
             if let Some(window) = window() {
                 if let Err(e) = js_sys::Reflect::set(
                     &window,
                     &JsValue::from_str("openTflKeyPanel"),
-                    &open_key_callback.as_ref()
+                    &open_key_callback.as_ref(),
                 ) {
                     logger.error(&format!("Failed to set openTflKeyPanel: {:?}", e));
                 } else {
                     logger.info("Successfully exposed openTflKeyPanel to JavaScript");
                 }
             }
-    
+
             // Forget the closure to prevent memory leaks
             open_key_callback.forget();
         });

--- a/src/app/simulation/mod.rs
+++ b/src/app/simulation/mod.rs
@@ -56,7 +56,7 @@ pub fn expose_simulation_functions(tfl_data: Option<TflDataRepository>) -> Resul
             let reset_closure = Closure::wrap(Box::new({
                 let tfl_data_inner = tfl_data_for_reset;
                 move || {
-                        log::info_with_category(
+                    log::info_with_category(
                         LogCategory::Simulation,
                         "rust_reset_simulation called from JS",
                     );

--- a/src/data/line_definitions.rs
+++ b/src/data/line_definitions.rs
@@ -18,50 +18,166 @@ pub struct LineInfo {
 }
 
 pub const LINE_INFOS: &[LineInfo] = &[
-    LineInfo { id: "bakerloo", name: "Bakerloo", color: "#B36305", line_type: LineType::Underground },
-    LineInfo { id: "central", name: "Central", color: "#E32017", line_type: LineType::Underground },
-    LineInfo { id: "circle", name: "Circle", color: "#FFD300", line_type: LineType::Underground },
-    LineInfo { id: "district", name: "District", color: "#00782A", line_type: LineType::Underground },
-    LineInfo { id: "hammersmith-city", name: "Hammersmith & City", color: "#F3A9BB", line_type: LineType::Underground },
-    LineInfo { id: "jubilee", name: "Jubilee", color: "#A0A5A9", line_type: LineType::Underground },
-    LineInfo { id: "metropolitan", name: "Metropolitan", color: "#9B0056", line_type: LineType::Underground },
-    LineInfo { id: "northern", name: "Northern", color: "#000000", line_type: LineType::Underground },
-    LineInfo { id: "piccadilly", name: "Piccadilly", color: "#003688", line_type: LineType::Underground },
-    LineInfo { id: "victoria", name: "Victoria", color: "#0098D4", line_type: LineType::Underground },
-    LineInfo { id: "waterloo-city", name: "Waterloo & City", color: "#95CDBA", line_type: LineType::Underground },
-    
-    LineInfo { id: "london-overground", name: "Overground", color: "#EE7C0E", line_type: LineType::Overground },
-    LineInfo { id: "dlr", name: "DLR", color: "#00A4A7", line_type: LineType::DLR },
-    LineInfo { id: "elizabeth", name: "Elizabeth Line", color: "#6950A1", line_type: LineType::ElizabethLine },
-    LineInfo { id: "tram", name: "Trams", color: "#84B817", line_type: LineType::Tram },
-    LineInfo { id: "cable-car", name: "Cable Car", color: "#E21836", line_type: LineType::CableCar },
-    LineInfo { id: "thameslink", name: "Thameslink", color: "#C1007C", line_type: LineType::Thameslink },
-    
+    LineInfo {
+        id: "bakerloo",
+        name: "Bakerloo",
+        color: "#B36305",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "central",
+        name: "Central",
+        color: "#E32017",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "circle",
+        name: "Circle",
+        color: "#FFD300",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "district",
+        name: "District",
+        color: "#00782A",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "hammersmith-city",
+        name: "Hammersmith & City",
+        color: "#F3A9BB",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "jubilee",
+        name: "Jubilee",
+        color: "#A0A5A9",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "metropolitan",
+        name: "Metropolitan",
+        color: "#9B0056",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "northern",
+        name: "Northern",
+        color: "#000000",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "piccadilly",
+        name: "Piccadilly",
+        color: "#003688",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "victoria",
+        name: "Victoria",
+        color: "#0098D4",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "waterloo-city",
+        name: "Waterloo & City",
+        color: "#95CDBA",
+        line_type: LineType::Underground,
+    },
+    LineInfo {
+        id: "london-overground",
+        name: "Overground",
+        color: "#EE7C0E",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "dlr",
+        name: "DLR",
+        color: "#00A4A7",
+        line_type: LineType::DLR,
+    },
+    LineInfo {
+        id: "elizabeth",
+        name: "Elizabeth Line",
+        color: "#6950A1",
+        line_type: LineType::ElizabethLine,
+    },
+    LineInfo {
+        id: "tram",
+        name: "Trams",
+        color: "#84B817",
+        line_type: LineType::Tram,
+    },
+    LineInfo {
+        id: "cable-car",
+        name: "Cable Car",
+        color: "#E21836",
+        line_type: LineType::CableCar,
+    },
+    LineInfo {
+        id: "thameslink",
+        name: "Thameslink",
+        color: "#C1007C",
+        line_type: LineType::Thameslink,
+    },
     // New Overground Lines
-    LineInfo { id: "liberty", name: "Liberty Line", color: "#4C6366", line_type: LineType::Overground },
-    LineInfo { id: "lioness", name: "Lioness Line", color: "#FFA32B", line_type: LineType::Overground },
-    LineInfo { id: "mildmay", name: "Mildmay Line", color: "#088ECC", line_type: LineType::Overground },
-    LineInfo { id: "suffragette", name: "Suffragette Line", color: "#59C274", line_type: LineType::Overground },
-    LineInfo { id: "weaver", name: "Weaver Line", color: "#B43983", line_type: LineType::Overground },
-    LineInfo { id: "windrush", name: "Windrush Line", color: "#FF2E24", line_type: LineType::Overground },
+    LineInfo {
+        id: "liberty",
+        name: "Liberty Line",
+        color: "#4C6366",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "lioness",
+        name: "Lioness Line",
+        color: "#FFA32B",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "mildmay",
+        name: "Mildmay Line",
+        color: "#088ECC",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "suffragette",
+        name: "Suffragette Line",
+        color: "#59C274",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "weaver",
+        name: "Weaver Line",
+        color: "#B43983",
+        line_type: LineType::Overground,
+    },
+    LineInfo {
+        id: "windrush",
+        name: "Windrush Line",
+        color: "#FF2E24",
+        line_type: LineType::Overground,
+    },
 ];
 
 // Helper functions
 pub fn get_line_color(line_id: &str) -> String {
-    LINE_INFOS.iter()
+    LINE_INFOS
+        .iter()
         .find(|info| info.id == line_id)
         .map(|info| info.color.to_string())
         .unwrap_or_else(|| "#777777".to_string())
 }
 
 pub fn get_underground_lines() -> Vec<&'static LineInfo> {
-    LINE_INFOS.iter()
+    LINE_INFOS
+        .iter()
         .filter(|info| matches!(info.line_type, LineType::Underground))
         .collect()
 }
 
 pub fn get_other_rail_lines() -> Vec<&'static LineInfo> {
-    LINE_INFOS.iter()
+    LINE_INFOS
+        .iter()
         .filter(|info| !matches!(info.line_type, LineType::Underground))
         .collect()
 }
@@ -69,19 +185,21 @@ pub fn get_other_rail_lines() -> Vec<&'static LineInfo> {
 /// Generate CSS for the lines
 pub fn generate_line_css() -> String {
     let mut css = String::new();
-    
+
     // Root variables
     css.push_str(":root {\n");
     for line in LINE_INFOS {
         css.push_str(&format!("  --{}: {};\n", line.id, line.color));
     }
     css.push_str("}\n\n");
-    
+
     // Line classes
     for line in LINE_INFOS {
-        css.push_str(&format!(".color-line.{} {{ background-color: var(--{}); }}\n", 
-            line.id, line.id));
+        css.push_str(&format!(
+            ".color-line.{} {{ background-color: var(--{}); }}\n",
+            line.id, line.id
+        ));
     }
-    
+
     css
 }

--- a/src/data/line_definitions.rs
+++ b/src/data/line_definitions.rs
@@ -80,7 +80,7 @@ pub fn generate_line_css() -> String {
     // Line classes
     for line in LINE_INFOS {
         css.push_str(&format!(".color-line.{} {{ background-color: var(--{}); }}\n", 
-            line.id.replace("-", "_"), line.id));
+            line.id, line.id));
     }
     
     css

--- a/src/data/line_definitions.rs
+++ b/src/data/line_definitions.rs
@@ -1,0 +1,87 @@
+#[derive(Debug, Clone, Copy)]
+pub enum LineType {
+    Underground,
+    Overground,
+    DLR,
+    ElizabethLine,
+    Tram,
+    CableCar,
+    Thameslink,
+}
+
+#[derive(Debug, Clone)]
+pub struct LineInfo {
+    pub id: &'static str,
+    pub name: &'static str,
+    pub color: &'static str,
+    pub line_type: LineType,
+}
+
+pub const LINE_INFOS: &[LineInfo] = &[
+    LineInfo { id: "bakerloo", name: "Bakerloo", color: "#B36305", line_type: LineType::Underground },
+    LineInfo { id: "central", name: "Central", color: "#E32017", line_type: LineType::Underground },
+    LineInfo { id: "circle", name: "Circle", color: "#FFD300", line_type: LineType::Underground },
+    LineInfo { id: "district", name: "District", color: "#00782A", line_type: LineType::Underground },
+    LineInfo { id: "hammersmith-city", name: "Hammersmith & City", color: "#F3A9BB", line_type: LineType::Underground },
+    LineInfo { id: "jubilee", name: "Jubilee", color: "#A0A5A9", line_type: LineType::Underground },
+    LineInfo { id: "metropolitan", name: "Metropolitan", color: "#9B0056", line_type: LineType::Underground },
+    LineInfo { id: "northern", name: "Northern", color: "#000000", line_type: LineType::Underground },
+    LineInfo { id: "piccadilly", name: "Piccadilly", color: "#003688", line_type: LineType::Underground },
+    LineInfo { id: "victoria", name: "Victoria", color: "#0098D4", line_type: LineType::Underground },
+    LineInfo { id: "waterloo-city", name: "Waterloo & City", color: "#95CDBA", line_type: LineType::Underground },
+    
+    LineInfo { id: "london-overground", name: "Overground", color: "#EE7C0E", line_type: LineType::Overground },
+    LineInfo { id: "dlr", name: "DLR", color: "#00A4A7", line_type: LineType::DLR },
+    LineInfo { id: "elizabeth", name: "Elizabeth Line", color: "#6950A1", line_type: LineType::ElizabethLine },
+    LineInfo { id: "tram", name: "Trams", color: "#84B817", line_type: LineType::Tram },
+    LineInfo { id: "cable-car", name: "Cable Car", color: "#E21836", line_type: LineType::CableCar },
+    LineInfo { id: "thameslink", name: "Thameslink", color: "#C1007C", line_type: LineType::Thameslink },
+    
+    // New Overground Lines
+    LineInfo { id: "liberty", name: "Liberty Line", color: "#4C6366", line_type: LineType::Overground },
+    LineInfo { id: "lioness", name: "Lioness Line", color: "#FFA32B", line_type: LineType::Overground },
+    LineInfo { id: "mildmay", name: "Mildmay Line", color: "#088ECC", line_type: LineType::Overground },
+    LineInfo { id: "suffragette", name: "Suffragette Line", color: "#59C274", line_type: LineType::Overground },
+    LineInfo { id: "weaver", name: "Weaver Line", color: "#B43983", line_type: LineType::Overground },
+    LineInfo { id: "windrush", name: "Windrush Line", color: "#FF2E24", line_type: LineType::Overground },
+];
+
+// Helper functions
+pub fn get_line_color(line_id: &str) -> String {
+    LINE_INFOS.iter()
+        .find(|info| info.id == line_id)
+        .map(|info| info.color.to_string())
+        .unwrap_or_else(|| "#777777".to_string())
+}
+
+pub fn get_underground_lines() -> Vec<&'static LineInfo> {
+    LINE_INFOS.iter()
+        .filter(|info| matches!(info.line_type, LineType::Underground))
+        .collect()
+}
+
+pub fn get_other_rail_lines() -> Vec<&'static LineInfo> {
+    LINE_INFOS.iter()
+        .filter(|info| !matches!(info.line_type, LineType::Underground))
+        .collect()
+}
+
+/// Generate CSS for the lines
+pub fn generate_line_css() -> String {
+    let mut css = String::new();
+    
+    // Root variables
+    css.push_str(":root {\n");
+    for line in LINE_INFOS {
+        css.push_str(&format!("  --{}: {};\n", line.id, line.color));
+    }
+    css.push_str("}\n\n");
+    
+    // Line classes
+    for line in LINE_INFOS {
+        css.push_str(&format!(".color-line.{} {{ background-color: var(--{}); }}\n", 
+            line.id.replace("-", "_"), line.id));
+    }
+    
+    css
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,3 +1,4 @@
+pub mod line_definitions;
 pub mod loader;
 pub mod map_helpers;
 pub mod model;


### PR DESCRIPTION
- **refactor: declarative key from data**
- **fix: use correct CSS class names, drop hardcoded CSS class definitions for line colours**
- **feat: use the key panel component rather than hardcoded JS one**
- **style: lint**
